### PR TITLE
Larapress will now build immediately after cloning the repo.

### DIFF
--- a/artisan
+++ b/artisan
@@ -17,11 +17,18 @@
 $_SERVER['SERVER_PROTOCOL'] = null;
 $_SERVER['REQUEST_METHOD'] = null;
 
+// LaraPress requirement
+if(!file_exists(__DIR__ . '/public/cms/wp-blog-header.php')) {
+    echo "WordPress hasn't been installed yet. Please run 'composer install'.";
+}
 require(__DIR__ . '/public/cms/wp-blog-header.php');
-/*
-require __DIR__.'/bootstrap/autoload.php';
 
-$app = require_once __DIR__.'/bootstrap/app.php';*/
+/*
+// Default Laravel require statements
+require __DIR__ . '/bootstrap/autoload.php';
+$app = require_once __DIR__ . '/bootstrap/app.php';
+*/
+
 
 /*
 |--------------------------------------------------------------------------

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://wpackagist.org"
+            "url": "https://wpackagist.org"
         }
     ],
     "minimum-stability": "stable",
@@ -58,9 +58,6 @@
         "post-install-cmd": [
             "php artisan clear-compiled",
             "php artisan optimize"
-        ],
-        "pre-update-cmd": [
-            "php artisan clear-compiled"
         ],
         "post-update-cmd": [
             "php artisan optimize"


### PR DESCRIPTION
- Updated Wordpress Git repo to use HTTPS protocol.
- Composer now runs 'artisan clear-compiled' AFTER 'composer install' rather than before so that the vendor folder is guaranteed to exist.
- Added some help text if artisan fails because of a missing Wordpress installation.
